### PR TITLE
lib.io_worker: misplaced reference to deferred IO Worker

### DIFF
--- a/pox/lib/ioworker/io_worker.py
+++ b/pox/lib/ioworker/io_worker.py
@@ -89,8 +89,6 @@ class RecocoIOLoop(Task):
     return worker
 
   def remove_worker(self, worker):
-    if isinstance(worker, DeferredIOWorker):
-      worker = worker.io_worker
     worker.close()
     self.workers.discard(worker)
 


### PR DESCRIPTION
Fixing a bug
