### PR TITLE
Fixed handling of link-local traffic in l2_learning switch

### DIFF
--- a/pox/forwarding/l2_learning.py
+++ b/pox/forwarding/l2_learning.py
@@ -53,8 +53,8 @@ class LearningSwitch (EventMixin):
 
   For each new flow:
   1) Use source address and port to update address/port table
-  2) Does destination address fall into MAC Group Address range and
-     pass_mac_group_addrs parameter is unset?
+  2) Does destination address fall into Bridge Filtered MAC Group Address
+     range and pass_bf_frames parameter is unset?
      Yes:
         2a) Drop packet to avoid forwarding link-local traffic (LLDP, 802.1x)
             DONE
@@ -133,7 +133,7 @@ class LearningSwitch (EventMixin):
 
     self.macToPort[packet.src] = event.port # 1
 
-    if packet.dst.isBridgeFiltered() and (self.args['pass_mac_group_addrs'] == 0):
+    if packet.dst.isBridgeFiltered() and (self.args['pass_bf_frames'] == 0):
       drop()
       return
 
@@ -177,8 +177,8 @@ class l2_learning (EventMixin):
     LearningSwitch(event.connection, self.args)
 
 
-def launch (pass_mac_group_addrs=0):
+def launch (pass_bf_frames=0):
   """
   Starts an L2 learning switch.
   """
-  core.registerNew(l2_learning, {'pass_mac_group_addrs':int(pass_mac_group_addrs)})
+  core.registerNew(l2_learning, {'pass_bf_frames':int(pass_bf_frames)})

--- a/pox/forwarding/l2_learning.py
+++ b/pox/forwarding/l2_learning.py
@@ -84,7 +84,7 @@ class LearningSwitch (EventMixin):
     # We want to hear PacketIn messages, so we listen
     self.listenTo(connection)
 
-    log.info("Initializing LearningSwitch, args=%s", str(self.args))
+    #log.info("Initializing LearningSwitch, args=%s", str(self.args))
 
   def _handle_PacketIn (self, event):
     """

--- a/pox/forwarding/l2_learning.py
+++ b/pox/forwarding/l2_learning.py
@@ -53,9 +53,10 @@ class LearningSwitch (EventMixin):
 
   For each new flow:
   1) Use source address and port to update address/port table
-  2) Is ethertype LLDP?
+  2) Does destination address fall into MAC Group Address range and
+     pass_mac_group_addrs parameter is unset?
      Yes:
-        2a) Drop packet -- LLDP is never forwarded
+        2a) Drop packet to avoid forwarding link-local traffic (LLDP, 802.1x)
             DONE
   3) Is destination multicast?
      Yes:
@@ -72,15 +73,18 @@ class LearningSwitch (EventMixin):
      flow goes out the appopriate port
      6a) Send buffered packet out appopriate port
   """
-  def __init__ (self, connection):
+  def __init__ (self, connection, args):
     # Switch we'll be adding L2 learning switch capabilities to
     self.connection = connection
+    self.args = args
 
     # Our table
     self.macToPort = {}
 
     # We want to hear PacketIn messages, so we listen
     self.listenTo(connection)
+
+    log.info("Initializing LearningSwitch, args=%s", str(self.args))
 
   def _handle_PacketIn (self, event):
     """
@@ -129,7 +133,7 @@ class LearningSwitch (EventMixin):
 
     self.macToPort[packet.src] = event.port # 1
 
-    if packet.type == packet.LLDP_TYPE: # 2
+    if packet.dst.isBridgeFiltered() and (self.args['pass_mac_group_addrs'] == 0):
       drop()
       return
 
@@ -164,16 +168,17 @@ class l2_learning (EventMixin):
   """
   Waits for OpenFlow switches to connect and makes them learning switches.
   """
-  def __init__ (self):
+  def __init__ (self, args):
     self.listenTo(core.openflow)
+    self.args = args
 
   def _handle_ConnectionUp (self, event):
     log.debug("Connection %s" % (event.connection,))
-    LearningSwitch(event.connection)
+    LearningSwitch(event.connection, self.args)
 
 
-def launch ():
+def launch (pass_mac_group_addrs=0):
   """
   Starts an L2 learning switch.
   """
-  core.registerNew(l2_learning)
+  core.registerNew(l2_learning, {'pass_mac_group_addrs':int(pass_mac_group_addrs)})

--- a/pox/lib/addresses.py
+++ b/pox/lib/addresses.py
@@ -124,6 +124,19 @@ class EthAddr (object):
     """
     return True if (ord(self._value[0]) & 2) else False
 
+  def isBridgeFiltered (self):
+    """
+    Returns True if this is IEEE 802.1D MAC Bridge Filtered MAC Group Address,
+    01-80-C2-00-00-00 to 01-80-C2-00-00-0F. MAC frames that have a destination MAC address
+    within this range are not relayed by MAC bridges conforming to IEEE 802.1D
+    """
+    return  (ord(self._value[0]) == 0x01) \
+    	and (ord(self._value[1]) == 0x80) \
+    	and (ord(self._value[2]) == 0xC2) \
+    	and (ord(self._value[3]) == 0x00) \
+    	and (ord(self._value[4]) == 0x00) \
+    	and (ord(self._value[5]) <= 0x0F)
+
   @property
   def is_local (self):
     return self.isLocal()


### PR DESCRIPTION
Fixed l2_learning switch implementation to correctly handle frames
with destination addresses set to Bridge Filtered MAC Group Address
(LLDP, 802.1x, ...). Added a command line switch to implement non-
standard behavior of passing such frames (useful for making a fully
transparent bridge).
