### PR TITLE
added an alternative select mechanism for recoco that uses epoll

### DIFF
--- a/pox/lib/epoll_select.py
+++ b/pox/lib/epoll_select.py
@@ -1,0 +1,101 @@
+import select
+
+class EpollSelect(object):
+  """ a class that implements select.select() type behavior on top of epoll.
+      Necessary, because select() only works on FD_SETSIZE (typically 1024) fd's at a time
+  """
+
+  def __init__(self):
+    self.epoll = select.epoll()
+    self.fd_to_obj = {}
+    self.registered = {}
+    self.lastrl = []
+    self.lastrl_set = set()
+    self.lastwl = []
+    self.lastwl_set = set()
+
+  def select(self, rl, wl, xl, timeout=0):
+    """ emulate the select semantics on top of _epoll.
+        Note this tries to emulate the behavior of select.select() 
+          - you can pass a raw fd, or an object that answers to #fileno().
+          - will return the object that belongs to the fd
+    """
+
+    # a map of fd's that need to be modified. 
+    # fd -> flag to be set (0 for unregister fd)
+    modify={}
+
+    def modify_table(current_obj_list, old_fd_set, op):
+      """ add operations to modify the registered fd's for operation / epoll mask 'op'
+          Returns the old_fd_set you should pass in next time
+          Also updates the fd_to_obj map.
+          Yes, this is ugly. """
+      current_fd_set = set()
+      for obj in current_obj_list:
+        # iterate through current_obj_list, udpate fd to obj mapping, and create set of fds
+        fd = obj.fileno() if hasattr(obj, "fileno") else obj
+        self.fd_to_obj[fd] = obj
+        current_fd_set.add(fd)
+
+      # new fds to register (for this op)
+      new = current_fd_set - old_fd_set
+      for fd in new:
+        if not fd in modify:
+          modify[fd] = self.registered[fd] if fd in self.registered else 0
+        modify[fd] |= op
+      # fd's to remove (at least for this op)
+      expired = old_fd_set - current_fd_set
+      for fd in expired:
+        if not fd in modify:
+          modify[fd] = self.registered[fd] if fd in self.registered else 0
+        modify[fd] &= ~op
+
+      return current_fd_set
+
+    # optimization assumptions
+    # rl is large and rarely changes
+    if rl != self.lastrl:
+      self.last_rl_set = modify_table(rl, self.lastrl_set, select.EPOLLIN|select.EPOLLPRI)
+      self.lastrl = rl
+
+    if wl != self.lastwl:
+      self.lastwl_set = modify_table(wl, self.lastwl_set, select.EPOLLOUT)
+      self.lastwl = wl
+
+    # ignore XL. Tough luck, epoll /always/ checks for error conditions
+    # you should, anyway
+
+    # now execute the modify ops on the epoll object
+    for (fd, mask) in modify.iteritems():
+      if fd in self.registered:
+        if mask == 0:
+          self.epoll.unregister(fd)
+        else:
+          self.epoll.modify(fd, mask)
+          self.registered[fd] = mask
+      else:
+        if mask == 0:
+          raise AssertionError("This should never happen - a new fd was scheduled for modification but neither for read nor write_")
+        else:
+          self.epoll.register(fd, mask)
+          self.registered[fd] = mask
+
+    # now for the real beef
+    events = self.epoll.poll(timeout)
+
+    # convert the events list of (fd, event) tuple to the three lists expected by select users
+    retrl = []
+    retwl = []
+    retxl = []
+    for (fd, event) in events:
+      if event & (select.EPOLLIN|select.EPOLLPRI|select.EPOLLRDNORM|select.EPOLLRDBAND):
+        retrl.append(self.fd_to_obj[fd])
+      if event & (select.EPOLLOUT|select.EPOLLWRNORM|select.EPOLLWRBAND):
+        retwl.append(self.fd_to_obj[fd])
+      if event & (select.EPOLLERR|select.EPOLLHUP):
+        retxl.append(self.fd_to_obj[fd])
+
+    return (retrl, retwl, retxl)
+
+  def close(self):
+    self.epoll.close()

--- a/pox/lib/recoco/recoco.py
+++ b/pox/lib/recoco/recoco.py
@@ -28,6 +28,7 @@ import os
 import socket
 import pox.lib.util
 import random
+from pox.lib.epoll_select import EpollSelect
 
 CYCLE_MAXIMUM = 2
 
@@ -133,10 +134,10 @@ class Task (BaseTask):
 class Scheduler (object):
   """ Scheduler for Tasks """
   def __init__ (self, isDefaultScheduler = None, startInThread = True,
-                daemon = False):
+                daemon = False, useEpoll=False):
     self._ready = deque()
     self._hasQuit = False
-    self._selectHub = SelectHub(self)
+    self._selectHub = SelectHub(self, useEpoll)
     self._thread = None
     self._event = threading.Event()
 
@@ -484,20 +485,20 @@ class Send (BlockingOperation):
     task.rf = self._sendReturnFunc
     scheduler._selectHub.registerSelect(task, None, [self._fd], [self._fd])
 
-
 #TODO: just merge this in with Scheduler?
 class SelectHub (object):
   """
   This class is a single select() loop that handles all Select() requests for
   a scheduler as well as timed wakes (i.e., Sleep()).
   """
-  def __init__ (self, scheduler):
+  def __init__ (self, scheduler, useEpoll=False):
     # We store tuples of (elapse-time, task)
     self._sleepers = [] # Sleeping items stored as a heap
     self._incoming = Queue() # Threadsafe queue for new items
 
     self._scheduler = scheduler
     self._pinger = pox.lib.util.makePinger()
+    self.epoll = EpollSelect() if useEpoll else None
 
     self._ready = False
 
@@ -507,7 +508,6 @@ class SelectHub (object):
 
     # Ugly busy wait for initialization
     #while self._ready == False:
-    #  time.sleep(0.2)
 
   def _threadProc (self):
     tasks = {}
@@ -564,7 +564,12 @@ class SelectHub (object):
           self._return(t, ([],[],[]))
 
       if timeout is None: timeout = CYCLE_MAXIMUM
-      ro, wo, xo = select.select( rl.keys() + [self._pinger],
+      if self.epoll:
+        ro, wo, xo = self.epoll.select( rl.keys() + [self._pinger],
+                                  wl.keys(),
+                                  xl.keys(), timeout )
+      else:
+        ro, wo, xo = select.select( rl.keys() + [self._pinger],
                                   wl.keys(),
                                   xl.keys(), timeout )
 

--- a/pox/lib/recoco/recoco.py
+++ b/pox/lib/recoco/recoco.py
@@ -137,7 +137,7 @@ class Scheduler (object):
                 daemon = False, useEpoll=False):
     self._ready = deque()
     self._hasQuit = False
-    self._selectHub = SelectHub(self, useEpoll)
+    self._selectHub = SelectHub(self, useEpoll=useEpoll)
     self._thread = None
     self._event = threading.Event()
 

--- a/tests/unit/lib/epoll_select_test.py
+++ b/tests/unit/lib/epoll_select_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+import unittest
+import sys
+import os.path
+import SocketServer
+import threading
+import socket
+import signal
+
+from copy import copy
+
+sys.path.append(os.path.dirname(__file__) + "/../../..")
+
+from pox.lib.epoll_select import EpollSelect
+
+class TCPEcho(SocketServer.StreamRequestHandler):
+  def handle(self):
+    data = self.rfile.readline()
+    print "got data: %s" % data
+    self.wfile.write(data)
+
+class ForkingTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+  def start(self):
+    self.pid = os.fork()
+    if self.pid == 0:
+      # child
+      self.serve_forever()
+
+  def stop(self):
+    os.kill(self.pid, signal.SIGKILL)
+
+def sort_fdlists(rl,wl,xl) :
+  key = lambda(x): x.fileno() if hasattr(x, "fileno") else x
+
+  return (
+            sorted(rl, key=key),
+            sorted(wl, key=key),
+            sorted(xl, key=key)
+        )
+
+class EpollSelectTest(unittest.TestCase):
+  def setUp(self):
+    self.es = EpollSelect()
+    self.server = ForkingTCPServer(("localhost", 0), TCPEcho)
+    self.ip, self.port = self.server.server_address
+    self.server.start()
+
+  def tearDown(self):
+    self.es.close()
+    self.server.stop()
+
+  def test_create(self):
+    pass
+
+  def test_read_one_socket(self):
+    c = socket.create_connection( (self.ip, self.port))
+    ret  = self.es.select([c], [], [c], 0.1)
+    self.assertEqual(([],[],[]), ret)
+    # socket is ready to send?
+    ret  = self.es.select([c], [c], [c], 0.1)
+    self.assertEqual(([],[c],[]), ret)
+    # send stuff
+    c.send("Hallo\n")
+    # now we have something to read, right?
+    ret  = self.es.select([c], [], [c], 0.5)
+    self.assertEqual(([c],[],[]), ret)
+
+  def test_write_more_sockets(self):
+    c1 = socket.create_connection( (self.ip, self.port))
+    c2 = socket.create_connection( (self.ip, self.port))
+    c3 = socket.create_connection( (self.ip, self.port))
+    # note don't throw away the socket -- else it will be garbage collected
+    raw = c3.fileno()
+    seq = [ [c1], [c2], [c1,c2], [c1,c2, raw], [c1], [raw]]
+
+    check = lambda a,b: self.assertEqual(sort_fdlists(*a), sort_fdlists(*b))
+
+    #just the writes
+    for sockets in seq:
+     check(([],sockets,[]),self.es.select(sockets, sockets, sockets, 0))
+
+    # writes and reads in different order
+    for sockets in seq:
+      check( ([],[],[]), self.es.select(sockets, [], sockets, 0))
+      check( ([],sockets,[]), self.es.select(sockets, sockets, sockets, 0))
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
select() can only do 1024 fd's which is not enough for the debugger
enable by creating a scheduler with useEpoll=true
Linux only.
