### PR TITLE
removing bad merge effects

### DIFF
--- a/pox/lib/addresses.py
+++ b/pox/lib/addresses.py
@@ -123,18 +123,6 @@ class EthAddr (object):
     else:
       raise RuntimeError("Expected ethernet address to be a string of 6 raw bytes or some hex")
 
-  def isGlobal (self):
-    """
-    Returns True if this is a globally unique (OUI enforced) address.
-    """
-    return not self.isLocal()
-
-  def isLocal (self):
-    """
-    Returns True if this is a locally-administered (non-global) address.
-    """
-    return True if (ord(self._value[0]) & 2) else False
-
   def isBridgeFiltered (self):
     """
     Returns True if this is IEEE 802.1D MAC Bridge Filtered MAC Group Address,
@@ -147,14 +135,6 @@ class EthAddr (object):
     	and (ord(self._value[3]) == 0x00)
     	and (ord(self._value[4]) == 0x00)
     	and (ord(self._value[5]) <= 0x0F))
-
-  @property
-  def is_local (self):
-    return self.isLocal()
-
-  @property
-  def is_global (self):
-    return self.isGlobal()
 
   def isGlobal (self):
     """


### PR DESCRIPTION
isGlobal and isLocal were duplicated because of bad merge conflict resolution.
