### PR TITLE
log_service: Fix regression

### DIFF
--- a/pox/messenger/log_service.py
+++ b/pox/messenger/log_service.py
@@ -143,7 +143,7 @@ def launch ():
       if event is None:
         # Only do this the first time
         log.warning("Deferring firing up LogMessengerListener because Messenger isn't up yet")
-        core.addListenerByName("ComponentRegistered", realStart, once=True)
+      core.addListenerByName("ComponentRegistered", realStart, once=True)
       return
     if not core.hasComponent(LogMessengerListener.__name__):
       core.registerNew(LogMessengerListener)


### PR DESCRIPTION
a644d058c69 introduced a regression where if messenger wasn't up before the log service or didn't come up IMMEDIATELY after the log service first tried to come up, the log service would never be started.

Eventually, a component superclass/metaclass or some startup helper function should take the place of this code anyway, but fixing it anyway.

The problem is in the launch().  Specifically, it's with a nested function, realStart(), which is SUPPOSED to work like:

```
realStart:
  If the messenger is started, register the LogMessengerListener.  Done.
  If the messenger isn't started:
    Listen for ComponentRegistered so we can see if the messenger has started
    If it's the first time we've tried to start and failed (messenger is not up), complain.
```

The trick is that realStart is also the event handler for ComponentRegistered.  When it's called as an event handler, the "event" parameter will be something besides None.  But it's also called once directly by launch(), and THIS time ONLY, event is None.  That's how we know it's the first time.

Since indentation is added to line 146, it now only registers the event listener once (when event is None), and it's a one-shot listener.  Meaning if messenger going up isn't the first event that triggers the event handler, we stop listening for ComponentRegistered and we'll never hear about it when messenger actually DOES go up.
