### PR TITLE
libopenflow: wildcard wireformat converion only on FLOW_MOD

### DIFF
--- a/pox/openflow/libopenflow_01.py
+++ b/pox/openflow/libopenflow_01.py
@@ -609,13 +609,13 @@ class ofp_match (object):
       return "self.dl_dst is not of size 6"
     return None
 
-  def pack (self, assertstruct=True):
+  def pack (self, assertstruct=True, flow_mod=False):
     if(assertstruct):
       if self._assert() is not None:
         raise RuntimeError(self._assert())
 
     packed = ""
-    packed += struct.pack("!LH", self._wire_wildcards(self.wildcards), self.in_port or 0)
+    packed += struct.pack("!LH", self._wire_wildcards(self.wildcards) if flow_mod else self.wildcards, self.in_port or 0)
     if self.dl_src == None:
       packed += EMPTY_ETH.toRaw()
     elif type(self.dl_src) is bytes:
@@ -725,7 +725,7 @@ class ofp_match (object):
   def is_exact (self):
     return not self.is_wildcarded
 
-  def unpack (self, binaryString):
+  def unpack (self, binaryString, flow_mod=False):
     if (len(binaryString) < self.__len__()):
       return binaryString
     (wildcards, self._in_port) = struct.unpack_from("!LH", binaryString, 0)
@@ -738,7 +738,7 @@ class ofp_match (object):
     self._nw_dst = IPAddr(self._nw_dst)
 #    if USE_MPLS_MATCH:
 #      (self.mpls_label, self.mpls_tc) = struct.unpack_from("!IBxxx", binaryString, 40)
-    self.wildcards = self._normalize_wildcards(self._unwire_wildcards(wildcards)) # Overide
+    self.wildcards = self._normalize_wildcards(self._unwire_wildcards(wildcards) if flow_mod else wildcards) # Overide
     return binaryString[self.__len__():]
 
   def __len__ (self):
@@ -1855,7 +1855,7 @@ class ofp_flow_mod (ofp_header):
     packed = ""
     self.length = len(self)
     packed += ofp_header.pack(self)
-    packed += self.match.pack()
+    packed += self.match.pack(flow_mod=True)
     packed += struct.pack("!QHHHHLHH", self.cookie, self.command, self.idle_timeout, self.hard_timeout, self.priority, self.buffer_id & 0xffffffff, self.out_port, self.flags)
     for i in self.actions:
       packed += i.pack(assertstruct)
@@ -1865,7 +1865,7 @@ class ofp_flow_mod (ofp_header):
     if (len(binaryString) < 72):
       return binaryString
     ofp_header.unpack(self, binaryString[0:])
-    self.match.unpack(binaryString[8:])
+    self.match.unpack(binaryString[8:], flow_mod=True)
     (self.cookie, self.command, self.idle_timeout, self.hard_timeout, self.priority, self.buffer_id, self.out_port, self.flags) = struct.unpack_from("!QHHHHLHH", binaryString, 8 + len(self.match))
     if self.buffer_id == 0xffffffff:
       self.buffer_id = -1

--- a/tests/unit/openflow/libopenflow_01_test.py
+++ b/tests/unit/openflow/libopenflow_01_test.py
@@ -246,7 +246,7 @@ class ofp_command_test(unittest.TestCase):
       return "|".join(parts)
 
     def test_wildcards(match, expected):
-      (packed,) = struct.unpack_from("!L", match.pack())
+      (packed,) = struct.unpack_from("!L", match.pack(flow_mod=True))
       self.assertEquals(packed, expected, "packed: %s <> expected: %s" % (show_wildcards(packed), show_wildcards(expected)))
 
     # no dl type specified -> wildcards for nw/dl are cleared


### PR DESCRIPTION
see github ticket #30
Consistent with ovs's behavior which isn't terribly consistent in
itself.
