### PR TITLE
Update pox/openflow/libopenflow_01.py

### DIFF
--- a/pox/openflow/libopenflow_01.py
+++ b/pox/openflow/libopenflow_01.py
@@ -426,6 +426,7 @@ class ofp_match (object):
 #      match.mpls_label = 0
 #      match.mpls_tc = 0
     if isinstance(p, vlan):
+      match.dl_type = p.eth_type
       match.dl_vlan = p.id
       match.dl_vlan_pcp = p.pcp
       p = p.next


### PR DESCRIPTION
Fix bug with 802.1q VLAN parsing - otherwise flows are set with dl_type=0x8100
