### PR TITLE
PR: Add nx output_reg and reg_move; topo fix

### DIFF
--- a/pox/openflow/topology.py
+++ b/pox/openflow/topology.py
@@ -190,7 +190,7 @@ class OpenFlowSwitch (EventMixin, Switch):
     self._connection = None
     self._listeners = []
     self._reconnectTimeout = None # Timer for reconnection
-    self.xid_generator = xid_generator( ((dpid & 0x7FFF) << 16) + 1)
+    self._xid_generator = xid_generator( ((dpid & 0x7FFF) << 16) + 1)
 
   def _setConnection (self, connection, ofp=None):
     ''' ofp - a FeaturesReply message '''


### PR DESCRIPTION
Primarily, this adds nx_reg_move and nx_output_reg actions.
Secondarily, it fixes a misnamed variable in the OpenFlowSwitch topology class.
