### PR TITLE
Update of_01.py

### DIFF
--- a/pox/openflow/of_01.py
+++ b/pox/openflow/of_01.py
@@ -763,7 +763,7 @@ class Connection (EventMixin):
         continue
 
     if offset != 0:
-      self.buf = self.buf[offset:]
+      self.buf = self.buf[offset+1:]
 
     return True
 


### PR DESCRIPTION
When SoftwareSwich is operated via TCP connection, the receiving buffer of OF parser sometimes contains the last byte of previous message. This commit is fixing that.
