### PR TITLE
log: Fix --no-default option

### DIFF
--- a/pox/log/__init__.py
+++ b/pox/log/__init__.py
@@ -97,7 +97,7 @@ def launch (__INSTANCE__ = None, **kw):
     use_kw = k.startswith("*")
     if use_kw: k = k[1:]
     k = k.lower()
-    if k == "no-default" and v:
+    if k == "no_default" and v:
       import pox.core
       logging.getLogger().removeHandler(pox.core._default_log_handler)
       logging.getLogger().addHandler(logging.NullHandler())


### PR DESCRIPTION
This is a regression caused by d8b65a739a5f, which turns hyphens
into underscores to make them compatible with actual argument
names in the launch function.  In this particular case, it's
not necessary, because no-default is put into kwargs and CAN
have hyphens, but boot doesn't take that into account.

It could, though.  And maybe it should.  At this point, boot
could use some work in general (e.g., refactoring and cleanup
based on the new help component), so maybe we should come back
to this at some point.

Thanks to Alison Chan for the bug report.
(cherry picked from commit 5fc413bd32050871d1d072d933819af0610d6370)
