### PR TITLE
arp_responder: copy request's vlan tag onto the answer

### DIFF
--- a/pox/misc/arp_responder.py
+++ b/pox/misc/arp_responder.py
@@ -31,6 +31,7 @@ log = core.getLogger()
 
 from pox.lib.packet.ethernet import ethernet, ETHER_BROADCAST
 from pox.lib.packet.arp import arp
+from pox.lib.packet.vlan import vlan
 from pox.lib.addresses import IPAddr, EthAddr
 from pox.lib.util import dpid_to_str, str_to_bool
 from pox.lib.recoco import Timer
@@ -215,6 +216,13 @@ class ARPResponder (object):
               e = ethernet(type=packet.type, src=_dpid_to_mac(dpid),
                             dst=a.hwsrc)
               e.payload = r
+              if packet.type == ethernet.VLAN_TYPE:
+                v_rcv = packet.find('vlan')
+                e.next = vlan(eth_type = e.type,
+                              next = e.payload,
+                              id = v_rcv.id,
+                              pcp = v_rcv.pcp)
+                e.type = ethernet.VLAN_TYPE
               log.info("%s answering ARP for %s" % (dpid_to_str(dpid),
                 str(r.protosrc)))
               msg = of.ofp_packet_out()


### PR DESCRIPTION
If flowspaces are separated by vlan ranges, then the current arp_responder doesn't work since the arp request and the response in the packet_out might not fall into the same flowspace.  This patch solves this problem.

I think of arp_responder as some kind of example code, therefore it may not worth making the code more complex with this patch.  Nevertheless, others may run into this issue as well, so please consider applying something similar to the pull request.

Thank you.
