### PR TITLE
arp_responder: copy request's vlan tag onto the answer (v2)

### DIFF
--- a/pox/misc/arp_responder.py
+++ b/pox/misc/arp_responder.py
@@ -31,6 +31,7 @@ log = core.getLogger()
 
 from pox.lib.packet.ethernet import ethernet, ETHER_BROADCAST
 from pox.lib.packet.arp import arp
+from pox.lib.packet.vlan import vlan
 from pox.lib.addresses import IPAddr, EthAddr
 from pox.lib.util import dpid_to_str, str_to_bool
 from pox.lib.recoco import Timer
@@ -215,6 +216,13 @@ class ARPResponder (object):
               e = ethernet(type=packet.type, src=_dpid_to_mac(dpid),
                             dst=a.hwsrc)
               e.payload = r
+              if packet.type == ethernet.VLAN_TYPE:
+                v_rcv = packet.find('vlan')
+                e.payload = vlan(eth_type = e.type,
+                                 payload = e.payload,
+                                 id = v_rcv.id,
+                                 pcp = v_rcv.pcp)
+                e.type = ethernet.VLAN_TYPE
               log.info("%s answering ARP for %s" % (dpid_to_str(dpid),
                 str(r.protosrc)))
               msg = of.ofp_packet_out()


### PR DESCRIPTION
I hope this is the right way of resubmitting #82.  (I verified the correctness of this vlan tagging using only my own arp responder code.)

I haven't known about arp_helper since it's not in betta.  Somehow it was a surprise to me that raiseEvent can collect feedbacks from the listeners.  I'd volunteer to rewrite arp_respoder to use it, but I'm too busy right now. 
