### PR TITLE
datapaths: Fix data field in echo_reply

### DIFF
--- a/pox/datapaths/switch.py
+++ b/pox/datapaths/switch.py
@@ -233,7 +233,7 @@ class SoftwareSwitchBase (object):
     """
     Handles echo requests
     """
-    msg = ofp_echo_reply(xid=ofp.xid)
+    msg = ofp_echo_reply(xid=ofp.xid, body=ofp.body)
     self.send(msg)
 
   def _rx_features_request (self, ofp, connection):


### PR DESCRIPTION
The echo reply should copy the exact data from echo request.
