### PR TITLE
fix buffer_id initial value bug

### DIFF
--- a/pox/openflow/libopenflow_01.py
+++ b/pox/openflow/libopenflow_01.py
@@ -2200,6 +2200,8 @@ class ofp_flow_mod (ofp_header):
     packed = b""
     packed += ofp_header.pack(self)
     packed += self.match.pack(flow_mod=True)
+    if self._buffer_id < 0:
+        self._buffer_id = NO_BUFFER
     packed += struct.pack("!QHHHHLHH", self.cookie, self.command,
                           self.idle_timeout, self.hard_timeout,
                           self.priority, self._buffer_id, self.out_port,


### PR DESCRIPTION
some controllers or switches use -1 (or other negative values) to stand for NO_BUFFER, e.g. riplpox, 

the line 

 packed += struct.pack("!QHHHHLHH", self.cookie, self.command,
                            self.idle_timeout, self.hard_timeout,
                            self.priority, self._buffer_id, self.out_port,

will generate a "integer out of range for 'L' format code" exception 

so add two lines to prevent this situation
