### PR TITLE
Add new RoleReply event to Nicira extensions

### DIFF
--- a/pox/openflow/nicira.py
+++ b/pox/openflow/nicira.py
@@ -2570,15 +2570,25 @@ def _init_unpacker ():
 _old_handler = None
 
 from pox.openflow import PacketIn
+from pox.lib.revent import Event
+class RoleReply (Event):
+  def __init__ (self, connection, ofp):
+    Event.__init__(self)
+    self.connection = connection
+    self.ofp = ofp
+    self.role = ofp.role
+    self.dpid = connection.dpid
+core.openflow._eventMixin_events.add(RoleReply)
 
 def _handle_VENDOR (con, msg):
   if isinstance(msg, nxt_packet_in) and core.NX.convert_packet_in:
     e = con.ofnexus.raiseEventNoErrors(PacketIn, con, msg)
     if e is None or e.halt != True:
       con.raiseEventNoErrors(PacketIn, con, msg)
-#  elif isinstance(msg, nxt_role_reply):
-#    pass
-#    #TODO
+  elif isinstance(msg, nx_role_reply):
+    e = con.ofnexus.raiseEventNoErrors(RoleReply, con, msg)
+    if e is None or e.halt != True:
+      con.raiseEventNoErrors(RoleReply, con, msg)
   else:
     _old_handler(con, msg)
 


### PR DESCRIPTION
We can send RoleRequest message, but we can't handle a reply for it. So I added a new RoleReply event that anyone can handle using common methods (_handle_RoleReply, etc.).
