### PR TITLE
core: Add RereadConfiguration event.  Signal SIGHUP fires it. (v2)

### DIFF
--- a/pox/boot.py
+++ b/pox/boot.py
@@ -178,7 +178,8 @@ def _do_launch (argv):
     core = pox.core.core
     core.getLogger('boot').debug('Using existing POX core')
   else:
-    core = pox.core.initialize(_options.threaded_selecthub)
+    core = pox.core.initialize(_options.threaded_selecthub,
+                               _options.handle_signals)
 
   _pre_startup()
   modules = _do_imports(n.split(':')[0] for n in component_order)
@@ -378,6 +379,7 @@ class POXOptions (Options):
     self.enable_openflow = True
     self.log_config = None
     self.threaded_selecthub = True
+    self.handle_signals = True
 
   def _set_h (self, given_name, name, value):
     self._set_help(given_name, name, value)


### PR DESCRIPTION
I've tried to take into account everything what was suggested in #105. However,
1. I didn't documented the new '--handle-signals' option in boot.py:352, because I don't think it is "notable".  Probably, I should document it elsewhere.
2. There is no signals.SIGHUP on Windows:

```
    Python 2.7.1 (r271:86832, Nov 27 2010, 18:30:46) [MSC v.1500 32 bit (Intel)] on
    win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import signal
    >>> signal.getsignal(signal.SIGHUP)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    AttributeError: 'module' object has no attribute 'SIGHUP'
    >>> signal.getsignal(signal.SIGINT)
    <built-in function default_int_handler>
    >>> 
```
