### PR TITLE
Match with wildcard never used

### DIFF
--- a/pox/forwarding/l3_learning.py
+++ b/pox/forwarding/l3_learning.py
@@ -211,8 +211,7 @@ class l3_switch (EventMixin):
                                 hard_timeout=of.OFP_FLOW_PERMANENT,
                                 buffer_id=event.ofp.buffer_id,
                                 actions=actions,
-                                match=of.ofp_match.from_packet(packet,
-                                                               inport))
+                                match=match)
           event.connection.send(msg.pack())
       elif self.arp_for_unknowns:
         # We don't know this destination.


### PR DESCRIPTION
The parameter "match" of ofp_flow_mod is created again and the object "match" from line 206 with configuration of wildcard from line 207 is never used
