### PR TITLE
allow ipv6 rules to be installed on ovs

### DIFF
--- a/pox/openflow/libopenflow_01.py
+++ b/pox/openflow/libopenflow_01.py
@@ -1183,12 +1183,12 @@ class ofp_match (ofp_base):
       packed += self.dl_dst.toRaw()
 
     def check_ip(val):
-      return (val or 0) if self.dl_type == 0x0800 else 0
+      return (val or 0) if (self.dl_type == 0x0800 or self.dl_type == 0x86dd) else 0
     def check_ip_or_arp(val):
-      return (val or 0) if self.dl_type == 0x0800 \
+      return (val or 0) if (self.dl_type == 0x0800 or self.dl_type == 0x86dd) \
                            or self.dl_type == 0x0806 else 0
     def check_tp(val):
-      return (val or 0) if self.dl_type == 0x0800 \
+      return (val or 0) if (self.dl_type == 0x0800 or self.dl_type == 0x86dd) \
                            and self.nw_proto in (1,6,17) else 0
 
     packed += struct.pack("!HB", self.dl_vlan or 0, self.dl_vlan_pcp or 0)
@@ -1240,7 +1240,7 @@ class ofp_match (ofp_base):
     but we won't quote it here because it seems to have a restrictive license.
     """
     #TODO: Set the masked fields to 0.
-    if self.dl_type == 0x0800:
+    if (self.dl_type == 0x0800 or self.dl_type == 0x86dd):
         # IP
         if  self.nw_proto not in (1,6,17):
           # not TCP/UDP/ICMP -> Clear TP wildcards for the wire
@@ -1262,7 +1262,7 @@ class ofp_match (ofp_base):
 
     The logic in this should exactly match that in _wire_wildcards()
     """
-    if self.dl_type == 0x0800:
+    if (self.dl_type == 0x0800 or self.dl_type == 0x86dd):
         # IP
         if  self.nw_proto not in (1,6,17):
           # not TCP/UDP/ICMP -> Clear TP wildcards for the wire
@@ -1298,7 +1298,7 @@ class ofp_match (ofp_base):
     protocol specified is as TCP, UDP or SCTP. Fields that are ignored
     don't need to be wildcarded and should be set to 0.
     """
-    if self._dl_type == 0x0800:
+    if (self._dl_type == 0x0800 or self._dl_type == 0x86dd):
         # IP
         if  self._nw_proto not in (1,6,17):
           # not TCP/UDP/ICMP -> Set TP wildcards for the object


### PR DESCRIPTION
When trying to install ipv6 rules either rules would be misinstalled 
For both rules that matched only on IPv6 (silent failure) or those that matched on IPv6 and nw_proto (WARNING:libopenflow_01:Fields ignored due to unspecified prerequisites: nw_proto), nw_proto and other wildcarded fields would be set zero.

E.g., cookie=0, duration_sec=36s, duration_nsec=396000000s, table_id=0, priority=60001, n_packets=0, n_bytes=0, idle_timeout=0,hard_timeout=0,dl_type=0x86dd,nw_tos=0x00,nw_proto=0,actions=
