### PR TITLE
py: add option for ipython console

### DIFF
--- a/pox/py.py
+++ b/pox/py.py
@@ -115,12 +115,17 @@ class Interactive (object):
         we_have_ipython = False
 
     if we_have_ipython:
+      banner = """POX's interactive interpreter is an IPython console now. 
+To revert to the builtin interactive interpreter, invoke the py component with 
+the --no-ipython option.
+
+Ready."""
       cfg = Config()
       cfg.PromptManager.in_template = r'POX (\#)> '
       cfg.PromptManager.in2_template = r' ... '
       cfg.PromptManager.out_template = r'Out (\#): '
       cfg.TerminalInteractiveShell.confirm_exit = False
-      start_console = lambda vars_: embed(config=cfg, user_global_ns=vars_, display_banner=False)
+      start_console = lambda vars_: embed(config=cfg, user_global_ns=vars_, banner1=banner)
     else:
       import code
       import sys

--- a/pox/py.py
+++ b/pox/py.py
@@ -60,7 +60,7 @@ class Interactive (object):
     core.register("Interactive", self)
     self.enabled = False
     self.completion = False
-    self.ipython = False
+    self.ipython = True
 
     #import pox.license
     import sys
@@ -106,6 +106,7 @@ class Interactive (object):
     time.sleep(1)
 
     # Check if we have ipython
+    we_have_ipython = False
     if self.ipython:
       try:
         from IPython import Config, embed
@@ -113,7 +114,7 @@ class Interactive (object):
       except ImportError:
         we_have_ipython = False
 
-    if self.ipython and we_have_ipython:
+    if we_have_ipython:
       cfg = Config()
       cfg.PromptManager.in_template = r'POX (\#)> '
       cfg.PromptManager.in2_template = r' ... '
@@ -134,7 +135,7 @@ class Interactive (object):
       core.quit()
 
 
-def launch (disable = False, completion = None, ipython = None, __INSTANCE__ = None):
+def launch (disable = False, completion = None, no_ipython = None, __INSTANCE__ = None):
   if not core.hasComponent("Interactive"):
     Interactive()
 
@@ -147,5 +148,5 @@ def launch (disable = False, completion = None, ipython = None, __INSTANCE__ = N
   core.Interactive.enabled = not disable
   if completion is not None:
     core.Interactive.completion = str_to_bool(completion)
-  if ipython is not None:
-    core.Interactive.ipython = str_to_bool(ipython)
+  if no_ipython is not None:
+    core.Interactive.ipython = not str_to_bool(no_ipython)

--- a/pox/py.py
+++ b/pox/py.py
@@ -120,19 +120,18 @@ class Interactive (object):
       cfg.PromptManager.in2_template = r' ... '
       cfg.PromptManager.out_template = r'Out (\#): '
       cfg.TerminalInteractiveShell.confirm_exit = False
-      self.running = True
-      embed(config=cfg, user_global_ns=self.variables, display_banner=False)
-      self.running = False
-      core.quit()
+      start_console = lambda vars_: embed(config=cfg, user_global_ns=vars_, display_banner=False)
     else:
       import code
       import sys
       sys.ps1 = "POX> "
       sys.ps2 = " ... "
-      self.running = True
-      code.interact('Ready.', local=self.variables)
-      self.running = False
-      core.quit()
+      start_console = lambda vars_: code.interact('Ready.', local=vars_)
+      
+    self.running = True
+    start_console(self.variables)
+    self.running = False
+    core.quit()
 
 
 def launch (disable = False, completion = None, no_ipython = None, __INSTANCE__ = None):

--- a/pox/py.py
+++ b/pox/py.py
@@ -125,7 +125,7 @@ Ready."""
       cfg.PromptManager.in2_template = r' ... '
       cfg.PromptManager.out_template = r'Out (\#): '
       cfg.TerminalInteractiveShell.confirm_exit = False
-      start_console = lambda vars_: embed(config=cfg, user_global_ns=vars_, banner1=banner)
+      start_console = lambda vars_: embed(config=cfg, user_ns=vars_, banner1=banner)
     else:
       import code
       import sys


### PR DESCRIPTION
This enables an IPython shell (instead of the default interactive python interpreter) to be started from the py module by passing it the --ipython command line option.
