### PR TITLE
openflow: Add Vendor event

### DIFF
--- a/pox/openflow/__init__.py
+++ b/pox/openflow/__init__.py
@@ -279,6 +279,18 @@ class ConfigurationReceived (Event):
     return (self.ofp.flags & of.OFPC_FRAG_MASK) == of.OFPC_FRAG_REASM
 
 
+class Vendor (Event):
+  """
+  Raised upon receipt of an OFPT_VENDOR message
+  """
+  def __init__ (self, connection, ofp):
+    self.connection = connection
+    self.ofp = ofp
+    self.dpid = connection.dpid
+    self.xid = ofp.xid
+    self.vendor = ofp.vendor
+
+
 class OpenFlowConnectionArbiter (EventMixin):
   """
   Determines which OpenFlowNexus gets the switch.
@@ -351,6 +363,7 @@ class OpenFlowNexus (EventMixin):
     QueueStatsReceived,
     FlowRemoved,
     ConfigurationReceived,
+    Vendor,
   ])
 
   # Bytes to send to controller when a packet misses all flows

--- a/pox/openflow/of_01.py
+++ b/pox/openflow/of_01.py
@@ -214,6 +214,9 @@ class DefaultOpenFlowHandlers (OpenFlowHandlers):
   @staticmethod
   def handle_VENDOR (con, msg):
     log.info("Vendor msg: " + str(msg))
+    e = con.ofnexus.raiseEventNoErrors(Vendor, con, msg)
+    if e is None or e.halt != True:
+      con.raiseEventNoErrors(Vendor, con, msg)   
 
   @staticmethod
   def handle_HELLO (con, msg): #S
@@ -711,6 +714,7 @@ class Connection (EventMixin):
     FlowRemoved,
     FeaturesReceived,
     ConfigurationReceived,
+    Vendor,
   ])
 
   # Globally unique identifier for the Connection instance


### PR DESCRIPTION
(This is more like an RFC than a pull request.)

I read how nicira.py supports vendor extensions.  It seems it installs a new general openflow handler.  I think in most cases there's a simpler way: the default handler should just raise an event for unknown vendor messages, which extension writers could easily catch.  

This patch adds support for raising an event when receiving an OFPT_VENDOR message.
