### PR TITLE
of_json: pass type of action to the underlying ofp_action_-classes

### DIFF
--- a/pox/openflow/of_json.py
+++ b/pox/openflow/of_json.py
@@ -150,7 +150,12 @@ def dict_to_action (d):
   cls = of._action_type_to_class[t]
   d['type'] = t
 
-  a = cls(**d)
+  try:
+    a = cls(**d)
+  except TypeError:
+    del d['type']
+    a = cls(**d)
+
   return a
 
 

--- a/pox/openflow/of_json.py
+++ b/pox/openflow/of_json.py
@@ -144,10 +144,12 @@ def dict_to_action (d):
     d['port'] = _fix_of_int(d['port'])
 
   t = d['type'].upper()
-  del d['type']
+
   if not t.startswith("OFPAT_"): t = "OFPAT_" + t
   t = of.ofp_action_type_rev_map[t]
   cls = of._action_type_to_class[t]
+  d['type'] = t
+
   a = cls(**d)
   return a
 


### PR DESCRIPTION
Is needed by ofp_action_dl_addr, ofp_action_nw_addr and ofp_action_tp_port.

The pull request "some action-functions in libopenflow_01 need the type set #158" will be closed.
