### PR TITLE
Defer delivering port_status received during handshake

### DIFF
--- a/pox/openflow/of_01.py
+++ b/pox/openflow/of_01.py
@@ -354,6 +354,10 @@ class HandshakeOpenFlowHandlers (OpenFlowHandlers):
     # To support old versions of cbench, just finish connecting here.
     #self._finish_connecting(con)
 
+  def handle_PORT_STATUS (self, con, msg): #A
+    log.debug("Got early port status on " + str(con) + " for port " + str(msg.desc.port_no))
+    con.defered_port_status.append(msg)
+
   def _finish_connecting (self, con):
     con.ofnexus._connect(con)
     con.info("connected")
@@ -370,6 +374,10 @@ class HandshakeOpenFlowHandlers (OpenFlowHandlers):
       if e is None or e.halt != True:
         con.raiseEventNoErrors(FeaturesReceived, con, con.features)
 
+    h = con.handlers[of.OFPT_PORT_STATUS]
+    for msg in con.defered_port_status:
+      h(con,msg)
+    con.defered_port_status = []
 
 statsHandlerMap = {
   of.OFPST_DESC : handle_OFPST_DESC,
@@ -743,6 +751,9 @@ class Connection (EventMixin):
 
     # Switch features reply.  Set during handshake.
     self.features = None
+
+    #Handle race condition where port status messages arrive before handshake finishes
+    self.defered_port_status = []
 
     # Switch desc stats reply.  Set during handshake ordinarily, but may
     # be None.

--- a/pox/openflow/of_01.py
+++ b/pox/openflow/of_01.py
@@ -355,8 +355,8 @@ class HandshakeOpenFlowHandlers (OpenFlowHandlers):
     #self._finish_connecting(con)
 
   def handle_PORT_STATUS (self, con, msg): #A
-    log.debug("Got early port status on " + str(con) + " for port " + str(msg.desc.port_no))
-    con.defered_port_status.append(msg)
+    con.info("Got early port status message for port " + str(msg.desc.port_no))
+    con._deferred_port_status.append(msg)
 
   def _finish_connecting (self, con):
     con.ofnexus._connect(con)
@@ -375,9 +375,9 @@ class HandshakeOpenFlowHandlers (OpenFlowHandlers):
         con.raiseEventNoErrors(FeaturesReceived, con, con.features)
 
     h = con.handlers[of.OFPT_PORT_STATUS]
-    for msg in con.defered_port_status:
+    for msg in con._deferred_port_status:
       h(con,msg)
-    con.defered_port_status = []
+    con._deferred_port_status = None
 
 statsHandlerMap = {
   of.OFPST_DESC : handle_OFPST_DESC,
@@ -753,7 +753,7 @@ class Connection (EventMixin):
     self.features = None
 
     #Handle race condition where port status messages arrive before handshake finishes
-    self.defered_port_status = []
+    self._deferred_port_status = []
 
     # Switch desc stats reply.  Set during handshake ordinarily, but may
     # be None.


### PR DESCRIPTION
POX currently drops port_status messages during the switch--controller handshake.
Unfortunately this leads to a race condition where important topology changes
can occur between the time that the features_reply message is received--
containing a complete list of ports at the moment it was sent--and the time
the handshake completes and port_status messages begin to be delivered.

This patch collects port_status messages received on a connection prior to the
switch--controller handshake completing and defers processing them, and sending
port_status events, until the connection completes.

Closes issue #162
