### PR TITLE
Don't convert the authentication token to lowercase.

### DIFF
--- a/pox/web/jsonrpc.py
+++ b/pox/web/jsonrpc.py
@@ -110,9 +110,9 @@ class JSONRPCHandler (SplitRequestHandler):
     if not self.auth_function:
       return True
 
-    auth = self.headers.get("Authorization", "").strip().lower()
+    auth = self.headers.get("Authorization", "").strip()
     success = False
-    if auth.startswith("basic "):
+    if auth.lower().startswith("basic "):
       try:
         auth = base64.decodestring(auth[6:].strip()).split(':', 1)
         success = self.auth_function(auth[0], auth[1])

--- a/pox/web/jsonrpc.py
+++ b/pox/web/jsonrpc.py
@@ -252,7 +252,7 @@ class JSONRPCHandler (SplitRequestHandler):
         return
       if 'id' in req or 'error' in response:
         response['id'] = req.get('id')
-        responses.append(response)
+      responses.append(response)
 
     if len(responses) == 0:
       responses = ''


### PR DESCRIPTION
Basic HTTP authentication fails due to lowercased Authorization header value.
