### PR TITLE
lack of resending in part6

### DIFF
--- a/pox/forwarding/l2_learning.py
+++ b/pox/forwarding/l2_learning.py
@@ -165,6 +165,14 @@ class LearningSwitch (object):
         # 6
         log.debug("installing flow for %s.%i -> %s.%i" %
                   (packet.src, event.port, packet.dst, port))
+        
+        ## resend packet #######################
+        msg_resend= of.ofp_packet_out()
+        msg_resend.data=event.ofp
+        action=of.ofp_action_output(port=port)
+        msg.actions.append(action)
+        connection.send(msg_resend)      
+        ###################################
         msg = of.ofp_flow_mod()
         msg.match = of.ofp_match.from_packet(packet, event.port)
         msg.idle_timeout = 10


### PR DESCRIPTION
in part6 (dst address in our table, so we will forward the packet according to the table, and install a new flow entry to the switch).
However, you only install a new flow entry to the switch and did not resend this packet which fire the event to the cooresponding destination. :)