### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pox/forwarding/l2_learning.py
+++ b/pox/forwarding/l2_learning.py
@@ -16,7 +16,7 @@
 An L2 learning switch.
 
 It is derived from one written live for an SDN crash course.
-It is somwhat similar to NOX's pyswitch in that it installs
+It is somewhat similar to NOX's pyswitch in that it installs
 exact-match rules for each flow.
 """
 
@@ -70,7 +70,7 @@ class LearningSwitch (object):
      Yes:
         5a) Drop packet and similar ones for a while
   6) Install flow table entry in the switch so that this
-     flow goes out the appopriate port
+     flow goes out the appropriate port
      6a) Send the packet out appropriate port
   """
   def __init__ (self, connection, transparent):

--- a/pox/messenger/__init__.py
+++ b/pox/messenger/__init__.py
@@ -114,7 +114,7 @@ class MissingChannel (Event):
 
 class MessageReceived (Event):
   """
-  Fired by a channel when a message has been receieved.
+  Fired by a channel when a message has been received.
 
   Always fired on the Connection itself.  Also fired on the corresponding
   Channel object as specified by the CHANNEL key.

--- a/pox/openflow/flow_table.py
+++ b/pox/openflow/flow_table.py
@@ -30,7 +30,7 @@ class TableEntry (object):
   """
   Models a flow table entry, with a match, actions, and options/flags/counters.
 
-  Note: The current time can either be specified explicitely with the optional
+  Note: The current time can either be specified explicitly with the optional
         'now' parameter or is taken from time.time()
   """
   def __init__ (self, priority=OFP_DEFAULT_PRIORITY, cookie=0, idle_timeout=0,

--- a/pox/openflow/of_01.py
+++ b/pox/openflow/of_01.py
@@ -1131,7 +1131,7 @@ class OpenFlow_01_Task (Task):
                 new_sock = wrap_socket(new_sock)
               new_sock.setblocking(0)
               # Note that instantiating a Connection object fires a
-              # ConnectionUp event (after negotation has completed)
+              # ConnectionUp event (after negotiation has completed)
               newcon = Connection(new_sock)
               sockets.append( newcon )
               #print str(newcon) + " connected"


### PR DESCRIPTION
There are small typos in:
- pox/forwarding/l2_learning.py
- pox/messenger/__init__.py
- pox/openflow/flow_table.py
- pox/openflow/of_01.py

Fixes:
- Should read `somewhat` rather than `somwhat`.
- Should read `received` rather than `receieved`.
- Should read `negotiation` rather than `negotation`.
- Should read `explicitly` rather than `explicitely`.
- Should read `appropriate` rather than `appopriate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md