### PR TITLE
Fix encode string in jsonrpc.py

### DIFF
--- a/pox/web/jsonrpc.py
+++ b/pox/web/jsonrpc.py
@@ -214,7 +214,7 @@ class JSONRPCHandler (SplitRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", len(response))
         self.end_headers()
-        self.wfile.write(response)
+        self.wfile.write(response.encode())
       except IOError as e:
         if e.errno == 32:
           if isinstance(orig, dict) and 'error' in orig:


### PR DESCRIPTION
This pull request includes a small change to the `pox/web/jsonrpc.py` file. The change ensures that the response is properly encoded before being written to the output stream.

* [`pox/web/jsonrpc.py`](diffhunk://#diff-ed9ed138d0fc079ade2769da3fd52c596b8164371683a78df33c301022a2ecc4L217-R217): Modified the `reply` method to encode the response before writing it to `wfile`.

**Original error:**
```
ERROR:web.jsonrpc:Exception while trying to send JSON-RPC response
Traceback (most recent call last):
  File "/home/mininet/pox/pox/web/jsonrpc.py", line 217, in reply
    self.wfile.write(response)
  File "/usr/lib/python3.8/socketserver.py", line 799, in write
    self._sock.sendall(b)
TypeError: a bytes-like object is required, not 'str'
```